### PR TITLE
Write annotations to Elucidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@
 
 5. Configure an AWS CLI profile with access tokens for Amazon Rekognition.
 6. Obtain an API key for Clarifai.
-7. Replace the dummy configuration data in `mgap.util.get_config`.
+7. Stand up and configure instances of the following:
+
+    - [IIIF](https://iiif.io) image server
+    - [Elucidate](https://github.com/dlcs/elucidate-server) WebAnnotation server
+    - RabbitMQ
+    - Redis
+
+8. Replace the dummy configuration data in `mgap.util.get_config`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ $ pytest
     c. In the third, pipe some JSON to the example send script:
 
     ```bash
-    $ echo '{ "iiif_image_info_url": "https://stacks.stanford.edu/image/iiif/gp903kf9548%2FSC1041_SAIL_Office_1979", "iiif_manifest_url": "https://purl.stanford.edu/gp903kf9548/iiif/manifest", "item_ark": "" }' | ./send_messages.py
+    $ echo '{ "iiif_image_info_url": "https://stacks.stanford.edu/image/iiif/gp903kf9548%2FSC1041_SAIL_Office_1979", "iiif_manifest_url": "https://purl.stanford.edu/gp903kf9548/iiif/manifest", "item_ark": "ark:/00000/aaa.bbb" }' | ./send_messages.py
     ```
 

--- a/mgap/mgap.py
+++ b/mgap/mgap.py
@@ -31,7 +31,8 @@ class MGAP:
                 )
             ),
             collect_computer_vision_results.s(config, message),
-            construct_annotation.s(config, message)
+            construct_annotation.s(config, message),
+            save_to_elucidate.s(config, message)
         )
 
     def send(self, x):

--- a/mgap/tasks.py
+++ b/mgap/tasks.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from urllib.parse import urlparse, unquote
 
@@ -144,7 +145,7 @@ def construct_annotation(computer_vision_results, config, message):
 
     # Each annotation has multiple bodies, one for each CV service result.
     for k, v in computer_vision_results.items():
-        anno_body = anno_body_seed
+        anno_body = copy.deepcopy(anno_body_seed)
         if v['vendor'] == 'amazon_rekognition':
             image_tags = list(map(
                 lambda x: x['Name'],

--- a/mgap/tasks.py
+++ b/mgap/tasks.py
@@ -1,6 +1,7 @@
 import copy
+import hashlib
 import json
-from urllib.parse import urlparse, unquote
+from urllib.parse import quote, unquote, urlparse
 
 from arrow import now
 from boto3 import Session as BotoSession
@@ -8,7 +9,7 @@ from botocore.client import Config as BotoConfig
 from clarifai.rest import ClarifaiApp
 from iiif.request import IIIFRequest
 from redis import Redis
-from requests import get
+from requests import get, head, post, put
 
 from .celery import app
 
@@ -176,3 +177,68 @@ def construct_annotation(computer_vision_results, config, message):
     anno['target']['selector']['region'] = '640,'
     anno['created'] = anno['generated'] = now('US/Pacific').isoformat()
     return anno
+
+@app.task
+def save_to_elucidate(annotation, config, message):
+    '''Sends a request to Elucidate to create or update an annotation and its container.
+
+    Args:
+        annotation: A dictionary representation of a WebAnnotation.
+
+    Returns:
+        The URL of the annotation on Elucidate.
+    '''
+
+    elucidate_headers_seed = config['elucidate']['request_headers_seed']
+    elucidate_base_url = '{}:{}/annotation/{}/'.format(
+        config['elucidate']['host'],
+        config['elucidate']['port'],
+        config['elucidate']['annotation_model']
+    )
+    annotation_container_slug = hashlib.md5(message['item_ark'].encode("utf-8")).hexdigest()
+    annotation_container_url = '{}{}/'.format(
+        elucidate_base_url,
+        annotation_container_slug
+    )
+    annotation_container_response = get(annotation_container_url)
+
+    # If container doesn't exist for the ARK, create it.
+    if annotation_container_response.status_code != 200:
+        annotation_container = {
+            **config['web_annotation']['annotation_container_seed'],
+            'label': message['item_ark']
+        }
+        create_annotation_container_response = post(
+            elucidate_base_url,
+            headers={
+                **elucidate_headers_seed,
+                'Slug': annotation_container_slug
+            },
+            data=json.dumps(annotation_container, indent=4, sort_keys=True)
+        )
+
+        # Annotation couldn't have existed without a container, so create it.
+        create_annotation_response = post(
+            annotation_container_url,
+            headers=elucidate_headers_seed,
+            data=json.dumps(annotation, indent=4, sort_keys=True)
+        )
+        annotation_url = create_annotation_response.json().get('id')
+    else:
+        # Annotation container and annotation already exist, so update.
+        annotation_url = annotation_container_response.json()['first']['items'][0]['id']
+
+        # Extract the inner contents of the weak ETag (W/"...").
+        etag = head(annotation_url).headers['etag'][3:-1]
+
+        # FIXME: don't overwrite the annotation! Much of it might not have changed, so retain timestamps, etc.
+        update_annotation_response = put(
+            annotation_url,
+            headers={
+                **elucidate_headers_seed,
+                'Content-Type': 'application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"',
+                'If-Match': etag
+            },
+            data=json.dumps(annotation, indent=4, sort_keys=True)
+        )
+    return annotation_url

--- a/mgap/util.py
+++ b/mgap/util.py
@@ -6,6 +6,16 @@ def get_config():
         'clarifai': {
             'api_key': ''
         },
+        'elucidate': {
+            'host': 'http://localhost',
+            'port': 8080,
+            'base_path': '/annotation',
+            'annotation_model': 'w3c',
+            'request_headers_seed': {
+                'Accept': 'application/ld+json;profile="http://www.w3.org/ns/anno.jsonld"',
+                'Content-Type': 'application/ld+json'
+            }
+        },
         'iiif': {
             'image_api_default_params': {
                 'region': 'full',
@@ -63,6 +73,10 @@ def get_config():
                 'generator': {
                     'type': 'Software'
                 }
+            },
+            'annotation_container_seed': {
+                '@context': 'http://www.w3.org/ns/anno.jsonld',
+                'type': 'AnnotationCollection'
             }
         }
     }

--- a/tests/fixtures/message_valid.json
+++ b/tests/fixtures/message_valid.json
@@ -1,1 +1,1 @@
-{ "iiif_image_info_url": "https://stacks.stanford.edu/image/iiif/gp903kf9548%2FSC1041_SAIL_Office_1979", "iiif_manifest_url": "https://purl.stanford.edu/gp903kf9548/iiif/manifest", "item_ark": "" }
+{ "iiif_image_info_url": "https://stacks.stanford.edu/image/iiif/gp903kf9548%2FSC1041_SAIL_Office_1979", "iiif_manifest_url": "https://purl.stanford.edu/gp903kf9548/iiif/manifest", "item_ark": "ark:/00000/aaa.bbb" }

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -49,8 +49,13 @@ def test_construct_annotation(computer_vision_results, messages, mgap_config):
     # Annotation body is a non-empty list.
     assert type(anno_body) is list and len(anno_body) > 0
 
-    # Body values are serialized JSON arrays of strings.
-    for body in anno_body:
+    # Bodies are unique.
+    for index, body in enumerate(anno_body):
+        for index_2, body_2 in enumerate(anno_body):
+            if index != index_2:
+                assert body != body_2
+
+        # Body values are serialized JSON arrays of strings.
         body_value = loads(body['value'])
         assert type(body_value) is list and len(body_value) > 0
         for element in body_value:


### PR DESCRIPTION
This is a first pass at writing annotations to Elucidate. Some fields on the annotation (`id`) and/or annotation container (`label`) may be incorrect, and properly updating annotations (e.g., detecting whether or not the computer vision results have changed or not between invocations of the pipeline, and thus whether to keep or overwrite timestamps on the annotation bodies and/or the annotation itself) is not supported, since I think it's not crucial at this point.

The PR also adds some info about external services to the README, and fixes a test that was passing when it shouldn't have been.